### PR TITLE
Handle deleted directories

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -5,7 +5,7 @@
 # * $path          package path
 # * $dependencies  package dependencies
 
-if status --is-interactive
+if status --is-interactive; and test -d $LAST_WORKING_DIR
     cd $LAST_WORKING_DIR
 end
 


### PR DESCRIPTION
It's possible that the last working directory is not existing anymore. One example is that it was created in `/tmp` and is automatically deleted on restart.

This currently results in

```
cd: The directory “/tmp/asdfasdfasdf” does not exist
/usr/share/fish/functions/cd.fish (line 40):
    builtin cd $argv
    ^
in function “cd”
	called on line 9 of file ~/.local/share/omf/pkg/last-working-dir/init.fish
	with parameter list “/tmp/asdfasdfasdf”

from sourcing file ~/.local/share/omf/pkg/last-working-dir/init.fish
	called during startup

in function “require”
	called on line 24 of file ~/.local/share/omf/init.fish
	with parameter list “--path /home/user/.local/share/omf/pkg/apt /home/user/.local/share/omf/pkg/autojump /home/user/.local/share/omf/pkg/foreign-env /home/user/.local/share/omf/pkg/last-working-dir /home/user/.local/share/omf/pkg/omf /home/user/.local/share/omf/pkg/pbcopy /home/user/.local/share/omf/pkg/sdk /home/user/.local/share/omf/pkg/yadd”

from sourcing file ~/.local/share/omf/init.fish
	called on line 7 of file ~/.config/fish/config.fish

from sourcing file ~/.config/fish/config.fish
	called during startup
```

The change will ignore the directory instead.